### PR TITLE
Chapter page load improvements

### DIFF
--- a/website/source/_static/map-widget-template.html
+++ b/website/source/_static/map-widget-template.html
@@ -1,4 +1,4 @@
-<div id="sidebar-##ID##" class="leaflet-sidebar collapsed" style="bottom:300px">
+<div id="sidebar-##ID##" class="leaflet-sidebar collapsed" style="bottom:300px; display:none">
     <!-- Nav tabs -->
     <div class="leaflet-sidebar-tabs">
         <ul role="tablist"> <!-- top aligned tabs -->

--- a/website/source/_static/map-widget-template.html
+++ b/website/source/_static/map-widget-template.html
@@ -24,7 +24,7 @@
     </div>
 </div>
 
-<div id="map-##ID##" style="height: 500px; width: 100%"></div>
+<div id="map-##ID##" style="height: 500px; width: 100%">loading...</div>
 <p><em id="map-caption-##ID##" style="font-size:0.9em"></em></p>
 
 <script>

--- a/website/source/_static/map-widget.js
+++ b/website/source/_static/map-widget.js
@@ -177,6 +177,7 @@ function init(id, options){
     container: 'sidebar-' + id,
     position: 'left',
   }).addTo(map);
+  $("#sidebar-" + id).css("display", "");  // overwrite default display:none
 
   // colorbar
   if(options.colorscale_name !== '' && options.colorscale_min !== '' && options.colorscale_name !== ''){

--- a/website/source/chapter/climatic-influence-plr.rst
+++ b/website/source/chapter/climatic-influence-plr.rst
@@ -1,6 +1,4 @@
 
-.. map-header::
-
 
 Climatic influence on PLR uncertainty
 =====================================
@@ -130,4 +128,7 @@ files listed below:
 
 .. geotiff-index::
     :pattern: geotiffs/synthetic-plr/*.tiff
+
+
+.. map-header::
 


### PR DESCRIPTION
Improve the page loading experience by:
- loading scripts at the end of the page (instead of the beginning), so that the rest of the content renders immediately
- hide map sidebar until it's ready to be shown.  this prevents them from momentarily spanning the full webpage height
- add placeholder "loading..." text to the map divs for the period before they are rendered