### PR TITLE
Fix broken maps

### DIFF
--- a/website/source/_static/map-header.html
+++ b/website/source/_static/map-header.html
@@ -1,14 +1,14 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css"/>
-<link rel="stylesheet" href="https://unpkg.com/leaflet-sidebar-v2/css/leaflet-sidebar.css"/>
+<link rel="stylesheet" href="https://unpkg.com/leaflet-sidebar-v2@3.2.3/css/leaflet-sidebar.css"/>
 <link rel="stylesheet" href="https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/leaflet.fullscreen.css"/>
 
 <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
-<script src="https://unpkg.com/georaster"></script>
-<script src="https://unpkg.com/geotiff"></script>
+<script src="https://unpkg.com/georaster@1.6.0"></script>
+<script src="https://unpkg.com/geotiff@2.1.3"></script>
 <script src="https://unpkg.com/chroma-js@2.4.2"></script>
-<script src="https://unpkg.com/georaster-layer-for-leaflet"></script>
-<script src="https://unpkg.com/geoblaze"></script>
-<script src="https://unpkg.com/leaflet-sidebar-v2"></script>
+<script src="https://unpkg.com/georaster-layer-for-leaflet@3.10.0"></script>
+<script src="https://unpkg.com/geoblaze@2.8.0"></script>
+<script src="https://unpkg.com/leaflet-sidebar-v2@3.2.3"></script>
 <script src="https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/Leaflet.fullscreen.min.js"></script>
 
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"/>

--- a/website/source/_static/map-widget.js
+++ b/website/source/_static/map-widget.js
@@ -278,7 +278,6 @@ function init(id, options){
     var layers = layerControl.getOverlays();
     for(var i = 0; i < layers.length; i++){
       var layer = layers[i];
-      console.log(layer);
       if(layer.name == e.name){
         text = "Description: " + layer.metadata['DESCRIPTION'] + " File date: " + layer.metadata["CREATION_DATE"] + ".";
         break;


### PR DESCRIPTION
The maps are currently misbehaving (partial display, switching layers when zooming in, toggling layers doesn't work, ...).

It was because of a new release of an unpinned dependency: https://github.com/GeoTIFF/georaster-layer-for-leaflet/releases

This PR pins everything.